### PR TITLE
Add environment.yml / check_environment.py

### DIFF
--- a/check_environment.py
+++ b/check_environment.py
@@ -1,0 +1,74 @@
+# This script is adapted from Andreas Mueller:
+# https://github.com/amueller/scipy-2018-sklearn/blob/master/check_env.ipynb
+# and glemaitre: https://github.com/glemaitre/pyparis-2018-sklearn/blob/master/check_environment.py
+
+from __future__ import print_function
+from distutils.version import LooseVersion as Version
+import sys
+
+
+try:
+    import curses
+    curses.setupterm()
+    assert curses.tigetnum("colors") > 2
+    OK = "\x1b[1;%dm[ OK ]\x1b[0m" % (30 + curses.COLOR_GREEN)
+    FAIL = "\x1b[1;%dm[FAIL]\x1b[0m" % (30 + curses.COLOR_RED)
+except:
+    OK = '[ OK ]'
+    FAIL = '[FAIL]'
+
+try:
+    import importlib
+except ImportError:
+    print(FAIL, "Python version 3.4 is required,"
+                " but %s is installed." % sys.version)
+
+
+def import_version(pkg, min_ver, fail_msg=""):
+    mod = None
+    try:
+        mod = importlib.import_module(pkg)
+        if pkg in {'PIL'}:
+            ver = mod.VERSION
+        elif pkg in {'xlrd'}:
+            ver = mod.__VERSION__
+        else:
+            ver = mod.__version__
+        if Version(ver) < min_ver:
+            print(FAIL, "%s version %s or higher required, but %s installed."
+                  % (lib, min_ver, ver))
+        else:
+            print(OK, '%s version %s' % (pkg, ver))
+    except ImportError:
+        print(FAIL, '%s not installed. %s' % (pkg, fail_msg))
+    return mod
+
+
+# first check the python version
+print('Using python in', sys.prefix)
+print(sys.version)
+pyversion = Version(sys.version)
+if pyversion >= "3":
+    if pyversion < "3.6":
+        print(FAIL, "Python version 3.6 is required,"
+                    " but %s is installed." % sys.version)
+else:
+    print(FAIL, "Python 3 is required, but %s is installed." % sys.version)
+
+print()
+requirements = {'numpy': "1.9", 'matplotlib': "2.0",
+                'pandas': "0.25", 'notebook': "5",
+                'plotnine': '0.6',
+                'pyproj': '1.9.5.1', 'requests': '2.18.0',
+                'seaborn': '0.9.0', 'xlrd': '1.1.0'}
+
+# now the dependencies
+for lib, required_version in list(requirements.items()):
+    import_version(lib, required_version)
+
+# mplleaflet has no option to derive __version__
+try:
+    import mplleaflet
+    print(OK, '%s can be loaded' % ('mplleaflet'))
+except:
+    print(FAIL, '%s can not be loaded.' % ('mplleaflet'))

--- a/check_environment.py
+++ b/check_environment.py
@@ -56,19 +56,10 @@ else:
     print(FAIL, "Python 3 is required, but %s is installed." % sys.version)
 
 print()
-requirements = {'numpy': "1.9", 'matplotlib': "2.0",
-                'pandas': "0.25", 'notebook': "5",
-                'plotnine': '0.6',
-                'pyproj': '1.9.5.1', 'requests': '2.18.0',
-                'seaborn': '0.9.0', 'xlrd': '1.1.0'}
+requirements = {'numpy': "1.9", 'matplotlib': "3.0",
+                'pandas': "1.0", 'requests': '2.18.0',
+                'seaborn': '0.10', 'xlrd': '1.1.0'}
 
 # now the dependencies
 for lib, required_version in list(requirements.items()):
     import_version(lib, required_version)
-
-# mplleaflet has no option to derive __version__
-try:
-    import mplleaflet
-    print(OK, '%s can be loaded' % ('mplleaflet'))
-except:
-    print(FAIL, '%s can not be loaded.' % ('mplleaflet'))

--- a/environment.yml
+++ b/environment.yml
@@ -1,18 +1,16 @@
-name: DS-python-data-analysis
+name: FLAMES-python
 channels:
 - defaults
 - conda-forge
 dependencies:
+- python=3.8
 - ipython
 - jupyter
+- jupyterlab
 - matplotlib>3
-- mplleaflet
-- notebook
 - numpy
-- pandas=0.25
+- pandas>=1.1
 - plotnine
-- pyproj
-- python=3.7
 - requests
 - seaborn
 - xlrd

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+name: DS-python-data-analysis
+channels:
+- defaults
+- conda-forge
+dependencies:
+- ipython
+- jupyter
+- matplotlib>3
+- mplleaflet
+- notebook
+- numpy
+- pandas=0.25
+- plotnine
+- pyproj
+- python=3.7
+- requests
+- seaborn
+- xlrd

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - jupyterlab
 - matplotlib>3
 - numpy
-- pandas>=1.1
+- pandas>=1.0
 - plotnine
 - requests
 - seaborn


### PR DESCRIPTION
The latest version of Anaconda to download uses Python 3.8 by default (https://www.anaconda.com/products/individual). But it has pandas 1.0.5, not pandas 1.1 (https://docs.anaconda.com/anaconda/reference/release-notes/), so we should probably ensure to test our notebooks with pandas 1.0 if we want that students can work with the stock latest Anaconda install (without requiring making a new environment)