### PR TITLE
Add geopandas as deps

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - jupyter
 - jupyterlab>=3
 - numpy
-- pandas>=1
+- pandas>2
 - matplotlib>3
 - mplleaflet
 - ipympl
@@ -16,3 +16,4 @@ dependencies:
 - pyproj
 - requests
 - openpyxl
+- geopandas


### PR DESCRIPTION
Just check if we want to add this dependency to enable the section `Joining with spatial data to make a map` in notebook 9. (Seperate PR here to be able to adjust quickly as mail has already been sent to participants)